### PR TITLE
better alternative text for MO5 logos

### DIFF
--- a/src/features/asso/asso.tsx
+++ b/src/features/asso/asso.tsx
@@ -2,12 +2,10 @@ import { langCtrl } from "../lang-selector/lang.ctrl"
 
 const txt = {
   fr: {
-    alt: 'Logo de l\'association MO5',
     speach: 'Après plus de vingt ans de préservation, de restauration et de transmission du patrimoine vidéoludique, l’association MO5 franchit une étape historique : la première phase de l’ouverture du Musée du Jeu Vidéo. Ce lieu, unique en France, sera entièrement consacré à l’histoire, à la culture et à la mémoire du jeu vidéo, de ses créateurs et de son influence sur la société contemporaine.',
     discoverAssociation: 'Découvrez l\'association MO5',
   },
   en: {
-    alt: 'Logo of the MO5 association',
     speach: 'After more than twenty years of preservation, restoration and transmission of the video game heritage, the MO5 association takes a historic step: the first phase of the opening of the Video Game Museum. This place, unique in France, will be entirely dedicated to the history, culture and memory of video games, its creators and its influence on contemporary society.',
     discoverAssociation: 'Discover the MO5 association',
   }
@@ -17,7 +15,7 @@ export const Asso = () => {
   return (
     <div class="flex flex-col gap-5 max-w-2xl mx-auto">
       <div class="flex flex-col md:flex-row gap-5 h-full justify-center items-center ">
-        <img src="/logo_blue.webp" alt={txt[lang() as keyof typeof txt].alt}
+        <img src="/logo_blue.webp" alt=""
           loading="lazy"
           width={100}
           height={87}

--- a/src/features/power-by/power-by.tsx
+++ b/src/features/power-by/power-by.tsx
@@ -3,11 +3,11 @@ import { langCtrl } from "../lang-selector/lang.ctrl"
 const txt = {
   fr: {
     powerBy: 'Créé par',
-    logoAlt: 'Logo de l\'association MO5',
+    logoAlt: 'Association MO5',
   },
   en: {
     powerBy: 'Created by',
-    logoAlt: 'Logo of the MO5 association',
+    logoAlt: 'MO5 association',
   },
 }
 
@@ -15,8 +15,8 @@ export const PowerBy = () => {
 
   const lang = langCtrl()
   return (
-    <div class="flex flex-col gap-2 justify-center items-center">
-      <p class="text-sm text-text/70 m-0">{txt[lang() as keyof typeof txt].powerBy}</p>
+    <p class="text-sm text-text/70 m-0 text-center">
+      {txt[lang() as keyof typeof txt].powerBy}
       <a href="https://mo5.com/" target="_blank" rel="noopener noreferrer">
         <img src="/logo.webp"
           width={194}
@@ -24,6 +24,6 @@ export const PowerBy = () => {
           alt={txt[lang() as keyof typeof txt].logoAlt}
           class="w-[194px] h-auto" />
       </a>
-    </div>
+    </p>
   )
 }

--- a/src/ui/Header/Header.tsx
+++ b/src/ui/Header/Header.tsx
@@ -14,12 +14,12 @@ type HeaderProps = {
 
 const txt = {
   fr: {
-    logoAlt: 'Logo de l\'association MO5',
-    logoLabel: 'Musée du Jeu Vidéo - Accueil',
+    logoMO5Alt: 'Association MO5',
+    logoMJVLabel: 'Musée du Jeu Vidéo - Accueil',
   },
   en: {
-    logoAlt: 'Logo of the MO5 association',
-    logoLabel: 'Video Game Museum - Home',
+    logoMO5Alt: 'MO5 association',
+    logoMJVLabel: 'Video Game Museum - Home',
   }
 }
 
@@ -51,7 +51,7 @@ export const Header = (props: HeaderProps) => {
             ease-in-out top-0 z-50 bg-bg"
         >
           <div class="flex items-center gap-4">
-            <div onClick={homeLink} class="cursor-pointer" role="link" tabindex="0" aria-label={txt[lang() as keyof typeof txt].logoLabel}>
+            <div onClick={homeLink} class="cursor-pointer" role="link" tabindex="0" aria-label={txt[lang() as keyof typeof txt].logoMJVLabel}>
               <Logo />
             </div>
             <MenuDesktop />
@@ -62,7 +62,7 @@ export const Header = (props: HeaderProps) => {
               <img src="/logo.webp"
                 width={194}
                 height={60}
-                alt={txt[lang() as keyof typeof txt].logoAlt}
+                alt={txt[lang() as keyof typeof txt].logoMO5Alt}
                 class="w-[120px] h-auto hidden md:block" />
             </a>
             <DarkMode />


### PR DESCRIPTION
Suppression de "Logo de" dans le header et le footer, et suppression totale dans le texte d'introduction où il est superflu dans le contexte.