### PR TITLE
Add underline to text links on hover

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -258,6 +258,10 @@
     @apply text-primary;
   }
 
+  a:not(.btn, .border) {
+    @apply focus:underline hover:underline;
+  }
+
   h1 {
     @apply text-4xl mb-6 mt-4 text-primary;
     font-family: 'Bebas Neue', sans-serif;


### PR DESCRIPTION
Fix #1478
<img width="217" height="156" alt="{2F85F032-5A21-4160-9AA1-73A2E93CF346}" src="https://github.com/user-attachments/assets/620c475f-56d0-407e-92b1-078de675d139" />
