### PR TITLE
improved nav and skip links

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -133,6 +133,14 @@
     background-color: var(--color-bg);
   }
 
+  :target {
+    scroll-margin-block: 2rem;
+  }
+
+  html {
+    scroll-padding-top: 2rem;
+  }
+
   /* ==== SCROLLBAR ==== */
   ::-webkit-scrollbar {
     width: 8px;

--- a/src/ui/Header/Header.tsx
+++ b/src/ui/Header/Header.tsx
@@ -15,10 +15,12 @@ type HeaderProps = {
 
 const txt = {
   fr: {
+    nav: 'Menu principal',
     logoMO5Alt: 'Association MO5',
     logoMJVLabel: 'Musée du Jeu Vidéo - Accueil',
   },
   en: {
+    nav: 'Main menu',
     logoMO5Alt: 'MO5 association',
     logoMJVLabel: 'Video Game Museum - Home',
   }
@@ -28,10 +30,15 @@ export const Header = (props: HeaderProps) => {
   const lang = langCtrl()
   const { t } = translate(txt)
 
-
   const homeLink = () => {
     window.history.pushState({}, '', `/${lang()}`)
     window.location.reload()
+  }
+
+  const onEnterKeyUp = (event: KeyboardEvent) => {
+    if (event.target instanceof HTMLElement && event.key === 'Enter') {
+      event.target.click()
+    }
   }
 
   return (
@@ -52,8 +59,8 @@ export const Header = (props: HeaderProps) => {
             flex justify-between items-center p-2
             ease-in-out top-0 z-50 bg-bg"
         >
-          <nav role="navigation" class="flex items-center gap-4">
-            <div onClick={homeLink} class="cursor-pointer" role="link" tabindex="0" aria-label={t().logoMJVLabel}>
+          <nav role="navigation" class="flex items-center gap-4" aria-label={t().nav}>
+            <div onClick={homeLink} onKeyUp={(e) => onEnterKeyUp(e)} class="cursor-pointer" role="link" tabindex="0" aria-label={t().logoMJVLabel}>
               <Logo />
             </div>
             <MenuDesktop />

--- a/src/ui/skip-links/skip-links.tsx
+++ b/src/ui/skip-links/skip-links.tsx
@@ -1,8 +1,26 @@
 import { txt } from './skip-links.txt'
-import { translate } from "~/utils/translate";
+import { translate } from "~/utils/translate"
 
 export const SkipLinks = () => {
-  const { t } = translate(txt);
+  const { t } = translate(txt)
 
-  return <a href="#main" class="border-2 border-primary bg-bg text-text text-xl m-2 p-4 absolute z-60 -translate-y-30 focus:translate-y-0">{t().main}</a>;
+  // Without this, the view scrolls to the target element but it doesn't receive focus, so you still have to tab through the menu links before reaching the main content.
+  // Shouldn't be necessary, maybe linked to how solidjs operates.
+  const targetFocus = (event: MouseEvent) => {
+    const targetId = event.target instanceof HTMLElement && event.target.getAttribute('href')
+
+    if (targetId) {
+      const targetElement = document.querySelector(targetId) as HTMLElement | null
+      if (targetElement) {
+        targetElement.setAttribute('tabindex', '-1') // make it focusable
+        targetElement.focus()
+      }
+    }
+  }
+
+  return (
+    <nav role="navigation" aria-label={t().nav}>
+      <a href="#main" onClick={(e) => targetFocus(e)} class="border-2 border-primary bg-bg text-text text-xl m-2 p-4 fixed z-60 -translate-y-30 focus:translate-y-0 focus:underline">{t().main}</a>
+    </nav>
+  )
 }

--- a/src/ui/skip-links/skip-links.txt.ts
+++ b/src/ui/skip-links/skip-links.txt.ts
@@ -1,8 +1,10 @@
 export const txt = {
   fr: {
+    nav: 'Accès rapide',
     main: 'Aller au contenu',
   },
   en: {
+    nav: 'Quick access',
     main: 'Skip to content',
   },
 }


### PR DESCRIPTION
After #1483 (game focus)

Improve skip links by making sure the target takes focus
Add scroll margin to make sure the target is visible
Announce navigation landmarks
Make the logo behave link a link (activate with Enter)