### PR TITLE
feat(museum-info): Rework museum status presentation (#1501)

### DIFF
--- a/src/features/break-modal/break-modal.const.ts
+++ b/src/features/break-modal/break-modal.const.ts
@@ -1,34 +1,11 @@
 export const breakModalTxt = {
-  // \xa0 = non-breaking space
   fr: {
-    pause1: "Chers amis,",
-    pause2:
-      "Depuis le 8 mars, le musée du jeu vidéo de l’association MO5 est entré dans une phase de transition. Des travaux de mise en conformité et de réaménagement du bâtiment, prévus de longue date, doivent débuter prochainement et s’étaler sur plusieurs mois.",
-    pause3: "Durant cette période, le musée est fermé au public.",
-    pause4: "À ce stade, une date de réouverture ne peut être communiquée.",
-    pause5: "Nous reviendrons rapidement vers vous avec de nouvelles informations.",
-    pause6: "D’ici là, l’association MO5 poursuit ses activités\xa0:",
-    pause7: "retrouvez-nous lors d’événements extérieurs (festivals, conventions, etc.)\xa0;",
-    pause8: "suivez nos actualités et les coulisses de nos collections sur nos réseaux sociaux\xa0;",
-    pause9: "soutenez l’association en adhérant.",
-    pause10: "Nous vous remercions pour votre compréhension.",
-    pause11: "L’équipe MO5",
+    videoAria: "Vidéo de présentation du musée du jeu vidéo",
     close: "OK",
     closeAria: "OK, cacher ce message et accéder au site",
   },
   en: {
-    pause1: "Dear friends,",
-    pause2:
-      "Since March 8th, the MO5 association's video game museum has entered a transition phase. Long-planned renovations and upgrades to the building are scheduled to begin soon and will last for several months.",
-    pause3: "During this period, the museum will be closed to the public.",
-    pause4: "At this time, we are unable to communicate on a reopening date.",
-    pause5: "We will be in touch with you soon with more information.",
-    pause6: "In the meantime, the MO5 association continues its activities:",
-    pause7: "Come see us at external events (festivals, conventions, etc.)",
-    pause8: "Follow our news and behind-the-scenes glimpses of our collections on our social media channels",
-    pause9: "Support the association by becoming a member",
-    pause10: "We are grateful for your patience.",
-    pause11: "The MO5 team",
+    videoAria: "Video presentation of the video game museum",
     close: "OK",
     closeAria: "OK, hide this message and access the website",
   },

--- a/src/features/break-modal/break-modal.tsx
+++ b/src/features/break-modal/break-modal.tsx
@@ -13,39 +13,45 @@ export const BreakModal = () => {
       <div class="fixed inset-0 flex items-center justify-center z-[9999] p-6">
         <dialog
           open
+          aria-labelledby="title-pause"
           class="
-          relative
-          max-h-[90dvh] w-full max-w-2xl
-          md:text-xl
-          p-4 border border-primary bg-bg text-text
-          overflow-y-auto overflow-x-hidden"
+            relative
+            max-h-[90dvh] w-full max-w-2xl
+            md:text-xl
+            p-4 border border-primary bg-bg text-text
+            overflow-y-auto overflow-x-hidden
+          "
           id="dialog-pause"
         >
           {/*
-          tabindex=0 to make sure the initial focus is at the top of the modal rather than on the button at the bottom on mobile devices
-          outline-0 used here since the title itself is not interactive
-      */}
-          <p id="title-pause" class="outline-0" tabindex="0" autofocus>
-            {t().pause1}
-          </p>
-          <p>
-            {t().pause2}
-            <br />
-            {t().pause3}
-          </p>
-          <p>
-            {t().pause4}
-            <br />
-            {t().pause5}
-          </p>
-          <p class="mb-0">{t().pause6}</p>
-          <ul class="list-disc m-4 mt-0">
-            <li>{t().pause7}</li>
-            <li>{t().pause8}</li>
-            <li>{t().pause9}</li>
-          </ul>
-          <p>{t().pause10}</p>
-          <p>{t().pause11}</p>
+          tabindex=0 to make sure the initial focus is at the top of the modal
+          rather than on the button at the bottom on mobile devices.
+          The title itself is not interactive so we use outline-0.
+          */}
+          <h2
+            id="title-pause"
+            class="sr-only outline-0"
+            tabindex="0"
+            autofocus
+          >
+            {t().videoAria}
+          </h2>
+
+          {/*
+          aspect-video wrapper keeps a 16:9 ratio so the iframe scales nicely
+          on every viewport and reacts smoothly to size changes.
+          */}
+          <div class="w-full aspect-video my-4">
+            <iframe
+              class="w-full h-full"
+              src="https://www.youtube.com/embed/8GUKuIOJyl4?autoplay=1&controls=1"
+              title={t().videoAria}
+              loading="lazy"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowfullscreen
+            />
+          </div>
+
           <div class="text-center">
             <button
               id="dialog-pause-close"

--- a/src/features/museum-info/museum-info.tsx
+++ b/src/features/museum-info/museum-info.tsx
@@ -1,0 +1,33 @@
+import { translate } from "~/utils/translate"
+import { museumInfoTxt } from "./museum-info.txt"
+
+export const MuseumInfo = () => {
+  const { t } = translate(museumInfoTxt)
+
+  return (
+    <div class="flex flex-col gap-2 max-w-4xl mx-auto">
+      <h2 class="text-4xl font-bold text-center">
+        {t().title}
+      </h2>
+      <p class="m-0">{t().greeting}</p>
+      <p class="m-0">
+        {t().intro1}
+        <br />
+        {t().intro2}
+      </p>
+      <p class="m-0">
+        {t().transition1}
+        <br />
+        {t().transition2}
+      </p>
+      <p class="m-0">{t().activitiesLabel}</p>
+      <ul class="list-disc m-4 mt-0">
+        <li>{t().activities1}</li>
+        <li>{t().activities2}</li>
+        <li>{t().activities3}</li>
+      </ul>
+      <p class="m-0">{t().thanks}</p>
+      <p>{t().team}</p>
+    </div>
+  )
+}

--- a/src/features/museum-info/museum-info.txt.ts
+++ b/src/features/museum-info/museum-info.txt.ts
@@ -1,0 +1,43 @@
+export const museumInfoTxt = {
+  fr: {
+    title: "Le musée du jeu vidéo",
+    greeting: "Chers amis,",
+    intro1:
+      "Depuis décembre 2025, l’association MO5 a ouvert le musée du jeu vidéo.",
+    intro2:
+      "Un lieu unique en France, entièrement géré par ses membres bénévoles, consacré à l’histoire, à la culture et à la mémoire du jeu vidéo, de ses créateurs et de son influence sur la société.",
+    transition1:
+      "Après une première phase réunissant plus de 900 visiteurs par jour, le musée est actuellement en réaménagement du bâtiment. L’ouverture est à ce jour en pause concernant l’accès au public.",
+    transition2:
+      "D’ici la fin de l’année, une date de réouverture sera communiquée sur nos réseaux. Nous reviendrons régulièrement vers vous avec de nouvelles informations.",
+    activitiesLabel: "Le musée et l’association MO5 poursuivent leurs activités\xa0:",
+    activities1:
+      "retrouvez-nous lors d’événements extérieurs (festivals, conventions, etc.)\xa0;",
+    activities2:
+      "suivez nos actualités et les coulisses de nos collections sur nos réseaux sociaux\xa0;",
+    activities3: "soutenez l’association en adhérant.",
+    thanks: "Nous vous remercions.",
+    team: "L’équipe MO5",
+  },
+  en: {
+    title: "Le musée du jeu vidéo",
+    greeting: "Dear friends,",
+    intro1:
+      "Since December 2025, the MO5 association has opened the video game museum.",
+    intro2:
+      "A unique place in France, entirely run by its volunteer members, dedicated to the history, culture and memory of video games, their creators and their influence on society.",
+    transition1:
+      "After a first phase welcoming more than 900 visitors per day, the museum is currently being refurbished. Public access is currently on hold.",
+    transition2:
+      "By the end of the year, a reopening date will be announced on our social media. We will be in touch with you regularly with new information.",
+    activitiesLabel:
+      "The museum and the MO5 association continue their activities:",
+    activities1:
+      "Come see us at external events (festivals, conventions, etc.);",
+    activities2:
+      "Follow our news and behind-the-scenes of our collections on our social media;",
+    activities3: "Support the association by becoming a member.",
+    thanks: "Thank you.",
+    team: "The MO5 team",
+  },
+}

--- a/src/routes/[lang]/index.tsx
+++ b/src/routes/[lang]/index.tsx
@@ -1,6 +1,7 @@
 import type { VoidComponent } from "solid-js";
 import { Address } from "~/features/address/address";
 import { Asso } from "~/features/asso/asso";
+import { MuseumInfo } from "~/features/museum-info/museum-info";
 import { Pictures } from "~/features/pictures/pictures";
 import { Supports } from "~/features/supports/supports";
 import { TakeATicket } from "~/features/ticket/take-a-ticket";
@@ -12,7 +13,8 @@ const Home: VoidComponent = () => {
     <main id="main" class="flex flex-col gap-12 p-4">
       {/* Pendant la pause md:grid-cols-1 sinon md:grid-cols-2 avec TakeATicket et Address en entier */}
       <div class="grid grid-rows-1 flex-wrap gap-2 w-full md:justify-between justify-center items-center md:grid-cols-1">
-        <Address />
+        {/*<Address />*/}
+        <MuseumInfo />
         <TakeATicket />
       </div>
       <Asso />


### PR DESCRIPTION
The previous text-based break modal has been replaced with an engaging video presentation. The detailed museum status information, previously shown in the modal, has been extracted into a new, dedicated `MuseumInfo` component and is now displayed prominently on the homepage. This update provides a more permanent and refreshed communication channel for visitors regarding the museum's current transition, and improves accessibility for the modal's video content.

Closes #1500